### PR TITLE
fix(borderoptions): correct typo in BorderOptions constructor

### DIFF
--- a/models/BorderOptions/BorderOptions.js
+++ b/models/BorderOptions/BorderOptions.js
@@ -30,7 +30,7 @@ class BorderOptions {
       Object.assign(this, BorderOptions.Model, {
         dashPattern: args.dashPattern,
         lineCapStyle: BorderOptions.LineCapStyle[args.lineCapStyle || 'butt'],
-        lineJoinStyle: BorderOptions.LineJoinStyle[args.lineCapStyle || 'miter'],
+        lineJoinStyle: BorderOptions.LineJoinStyle[args.lineJoinStyle || 'miter'],
       });
     }
   }


### PR DESCRIPTION
I found a typo in the constructor of the BorderOptions model, which prevented me of creating proper BorderOptions.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
