### PR TITLE
feat(models): added Oval model and convenience constructor in ShapeGroup

### DIFF
--- a/models/Oval/Oval.js
+++ b/models/Oval/Oval.js
@@ -1,0 +1,99 @@
+/*
+ * Copyright 2017 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"). You may not use this file except in compliance with
+ * the License. A copy of the License is located at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+ * CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions
+ * and limitations under the License.
+ */
+
+const uuid = require('uuid-v4');
+const Layer = require('../Layer');
+const CurvePoint = require('../CurvePoint');
+const Rect = require('../Rect');
+const Style = require('../Style');
+
+const points = [
+    '{0.5, 1}',
+    '{1, 0.5}',
+    '{0.5, 0}',
+    '{0, 0.5}'
+];
+const pointsFrom = [
+    '{0.77614237490000004, 1}',
+    '{1, 0.22385762510000001}',
+    '{0.22385762510000001, 0}',
+    '{0, 0.77614237490000004}'
+];
+const pointsTo = [
+    '{0.22385762510000001, 1}',
+    '{1, 0.77614237490000004}',
+    '{0.77614237490000004, 0}',
+    '{0, 0.22385762510000001}'
+];
+
+/**
+ *
+ */
+class Oval extends Layer {
+  /**
+   *
+   * @param {Object} args
+   * @param {String} args.name
+   * @param {integer} args.x
+   * @param {integer} args.y
+   * @param {integer} args.height
+   * @param {integer} args.width
+   * @param {Object} args.style Passed to {@link LayerStyle}
+   * @param {Oval.Model} json
+   */
+  constructor(args = {}, json) {
+    super(args, json);
+    if (!json) {
+      const id = args.id || uuid().toUpperCase();
+      Object.assign(this, Oval.Model, {
+        points: points.map(
+          (point, index) =>
+            new CurvePoint({
+              point,
+              curveFrom: pointsFrom[index],
+              curveTo: pointsTo[index],
+              curveMode: 2,
+              hasCurveFrom: true,
+              hasCurveTo: true,
+            })
+        ),
+        do_objectID: id,
+        frame: new Rect({
+          x: args.x,
+          y: args.y,
+          width: args.width,
+          height: args.height,
+        }),
+        style: new Style(args.style),
+        name: args.name || id,
+      });
+    }
+  }
+}
+
+/**
+ * @mixes Layer.Model
+ * @property {boolean} edited
+ * @property {boolean} isClosed
+ * @property {integer} pointRadiusBehaviour
+ * @property {String[]} points
+ */
+Oval.Model = Object.assign({}, Layer.Model, {
+  _class: 'oval',
+  edited: false,
+  isClosed: true,
+  pointRadiusBehaviour: 1,
+  points: [],
+});
+
+module.exports = Oval;

--- a/models/Oval/Oval.test.js
+++ b/models/Oval/Oval.test.js
@@ -1,0 +1,22 @@
+/*
+ * Copyright 2017 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"). You may not use this file except in compliance with
+ * the License. A copy of the License is located at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+ * CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions
+ * and limitations under the License.
+ */
+
+const Oval = require('./index');
+
+const json = {};
+
+describe('Oval', () => {
+  it('should work from raw JSON', () => {
+    expect(true).toBeTruthy();
+  });
+});

--- a/models/Oval/index.js
+++ b/models/Oval/index.js
@@ -1,0 +1,14 @@
+/*
+ * Copyright 2017 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"). You may not use this file except in compliance with
+ * the License. A copy of the License is located at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+ * CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions
+ * and limitations under the License.
+ */
+
+module.exports = require('./Oval');

--- a/models/ShapeGroup/ShapeGroup.js
+++ b/models/ShapeGroup/ShapeGroup.js
@@ -14,6 +14,7 @@
 const uuid = require('uuid-v4');
 const Layer = require('../Layer');
 const Rectangle = require('../Rectangle');
+const Oval = require('../Oval');
 const Rect = require('../Rect');
 const Style = require('../Style');
 
@@ -45,6 +46,28 @@ class ShapeGroup extends Layer {
       },
       layers: [
         new Rectangle({
+          x: 0,
+          y: 0,
+          width: args.width,
+          height: args.height,
+        }),
+      ],
+    });
+  }
+
+  static Oval(args) {
+    return new this({
+      name: args.name,
+      id: args.id,
+      style: args.style,
+      frame: {
+        x: args.x,
+        y: args.y,
+        width: args.width,
+        height: args.height,
+      },
+      layers: [
+        new Oval({
           x: 0,
           y: 0,
           width: args.width,

--- a/models/index.js
+++ b/models/index.js
@@ -25,6 +25,7 @@ module.exports = {
   Fill: require('./Fill'),
   Gradient: require('./Gradient'),
   Meta: require('./Meta'),
+  Oval: require('./Oval'),
   Page: require('./Page'),
   Rect: require('./Rect'),
   Rectangle: require('./Rectangle'),


### PR DESCRIPTION
*Description of changes:*
I implemented the `Oval` modal in order to be able to create circles and such things. I'm curious get some feedback on it (@dbanksdesign). Especially about the curve points I wasn't sure. I'm having a hard time hard coding them, but it seems to be working fine. Do you see any problems with that?

I also added a convenience constructor just like we have it for the `Rectangular` model.

Let me know what you think 🤔

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
