### PR TITLE
fix(SharedStyle): fixing issue with duplicate fill instantiation

### DIFF
--- a/models/SharedStyle/SharedStyle.js
+++ b/models/SharedStyle/SharedStyle.js
@@ -14,9 +14,6 @@
 const uuid = require('uuid-v4');
 const TextStyle = require('../TextStyle');
 const Style = require('../Style');
-const Fill = require('../Fill');
-const Border = require('../Border');
-const Shadow = require('../Shadow');
 
 class SharedStyle {
   static LayerStyle(args) {
@@ -24,9 +21,9 @@ class SharedStyle {
     return new SharedStyle({
       name: args.name,
       id,
-      fills: (args.fills || []).map(fill => new Fill(fill)),
-      borders: (args.borders || []).map(border => new Border(border)),
-      shadows: (args.shadows || []).map(shadow => new Shadow(shadow)),
+      fills: args.fills,
+      borders: args.borders,
+      shadows: args.shadows,
     });
   }
 

--- a/models/SharedStyle/SharedStyle.test.js
+++ b/models/SharedStyle/SharedStyle.test.js
@@ -26,4 +26,18 @@ describe('SharedStyle', () => {
     });
     expect(sharedStyle.name).toEqual('foo');
   });
+
+  describe('LayerStyle', () => {
+    it('should work', () => {
+      const layerStyle = SharedStyle.LayerStyle({
+        name: 'test',
+        fills: [
+          {
+            color: '#ff0000',
+          },
+        ],
+      });
+      expect(layerStyle.value.fills[0].color.red).toEqual(1);
+    });
+  });
 });


### PR DESCRIPTION

*Issue #, if available:* #21

*Description of changes:* Removing duplicate instantiation of the Fill class when calling `SharedStyle.LayerStyle`


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
