### PR TITLE
fix: wrap args.style with Style.TextStyle

### DIFF
--- a/models/Text/Text.js
+++ b/models/Text/Text.js
@@ -67,8 +67,7 @@ class Text extends Layer {
         userInfo: {},
 
         style:
-          args.style ||
-          Style.TextStyle({
+          Style.TextStyle(args.style || {
             fontName: args.fontName,
             fontSize: args.fontSize,
             alignment: args.alignment,


### PR DESCRIPTION
*Issue #25*

*Description of changes:*
Attempt to prevent the generated Sketch file from crashing when using style property on a Text

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
