### PR TITLE
fix: add index.d.ts to files

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
     "models",
     "utils",
     "index.js",
+    "index.d.ts",
     "LICENSE",
     "README.md",
     "NOTICE"


### PR DESCRIPTION
I forgot to put index.d.ts into "files" field in package.json so type definitions will not be found.

*Description of changes:*
add index.d.ts to "files" in package.json

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
