### PR TITLE
Idfix

### DIFF
--- a/models/Group/Group.js
+++ b/models/Group/Group.js
@@ -42,7 +42,7 @@ class Group extends Layer {
         layers: args.layers || [],
       });
     }
-    this = newIds(this);
+
     return this;
   }
 }
@@ -56,18 +56,5 @@ Group.Model = Object.assign({}, Layer.Model, {
   resizingConstraint: 63,
   hasClickThrough: false,
 });
-
-let newIds = obj => {
-  Object.keys(obj).forEach(key => {
-    if (key === 'do_objectID') {
-      obj[key] = uuidv1().toUpperCase();
-      return obj;
-    }
-    if (typeof obj[key] === 'object') {
-      newIds(obj[key]);
-    }
-  });
-  return obj;
-};
 
 module.exports = Group;

--- a/models/Group/Group.js
+++ b/models/Group/Group.js
@@ -42,7 +42,7 @@ class Group extends Layer {
         layers: args.layers || [],
       });
     }
-
+    this = newIds(this);
     return this;
   }
 }
@@ -56,5 +56,18 @@ Group.Model = Object.assign({}, Layer.Model, {
   resizingConstraint: 63,
   hasClickThrough: false,
 });
+
+let newIds = obj => {
+  Object.keys(obj).forEach(key => {
+    if (key === 'do_objectID') {
+      obj[key] = uuidv1().toUpperCase();
+      return obj;
+    }
+    if (typeof obj[key] === 'object') {
+      newIds(obj[key]);
+    }
+  });
+  return obj;
+};
 
 module.exports = Group;

--- a/models/Group/Group.js
+++ b/models/Group/Group.js
@@ -42,8 +42,8 @@ class Group extends Layer {
         layers: args.layers || [],
       });
     }
-    this = newIds(this);
-    return this;
+    let updated_obj = newId(this);
+    return updated_obj;
   }
 }
 
@@ -60,7 +60,7 @@ Group.Model = Object.assign({}, Layer.Model, {
 let newIds = obj => {
   Object.keys(obj).forEach(key => {
     if (key === 'do_objectID') {
-      obj[key] = uuidv1().toUpperCase();
+      obj[key] = uuid().toUpperCase();
       return obj;
     }
     if (typeof obj[key] === 'object') {

--- a/models/Group/Group.js
+++ b/models/Group/Group.js
@@ -32,18 +32,20 @@ class Group extends Layer {
    */
   constructor(args = {}, json) {
     super(args, json);
+    let return_obj = this;
     if (!json) {
       const id = args.id || uuid().toUpperCase();
-      Object.assign(this, Group.Model, {
+      Object.assign(return_obj, Group.Model, {
         do_objectID: id,
         name: args.name || id,
         frame: new Rect(args.frame),
         style: new Style(args.style),
         layers: args.layers || [],
       });
+      return_obj = createSublayerIds(this);
     }
-    let updated_obj = newId(this);
-    return updated_obj;
+
+    return return_obj;
   }
 }
 
@@ -57,17 +59,18 @@ Group.Model = Object.assign({}, Layer.Model, {
   hasClickThrough: false,
 });
 
-let newIds = obj => {
+let createSublayerIds = obj => {
   Object.keys(obj).forEach(key => {
     if (key === 'do_objectID') {
       obj[key] = uuid().toUpperCase();
       return obj;
     }
     if (typeof obj[key] === 'object') {
-      newIds(obj[key]);
+      createSublayerIds(obj[key]);
     }
   });
   return obj;
 };
+
 
 module.exports = Group;


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

Not sure if proper implementation point, but when constructing a Layer from a template, sub layers retained the same object ids, which made for some interesting selection scenarios in the assembled file (i.e. sublayers are essentially the same so selecting one will select all that were constructed in this manner).  If constructing from JSON, create new sub-ids so they'll be represented as different objects.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
