### PR TITLE
Textstyles lineheight and kerning

### DIFF
--- a/models/TextStyle/TextStyle.js
+++ b/models/TextStyle/TextStyle.js
@@ -52,6 +52,10 @@ class TextStyle {
           },
         },
       });
+      if (args.lineHeight) {
+        this.encodedAttributes.paragraphStyle.minimumLineHeight = args.lineHeight;
+        this.encodedAttributes.paragraphStyle.maximumLineHeight = args.lineHeight;
+      }
     }
   }
 
@@ -65,6 +69,10 @@ class TextStyle {
 
   getFontName() {
     return this.encodedAttributes.MSAttributedStringFontAttribute.attributes.name;
+  }
+
+  getLineHeight() {
+    return this.encodedAttributes.paragraphStyle.minimumLineHeight;
   }
 }
 
@@ -85,6 +93,8 @@ TextStyle.Model = {
     paragraphStyle: {
       _class: 'paragraphStyle',
       alignment: 0,
+      minimumLineHeight: 43,
+      maximumLineHeight: 43,
     },
   },
   verticalAlignment: 0,

--- a/models/TextStyle/TextStyle.js
+++ b/models/TextStyle/TextStyle.js
@@ -56,6 +56,9 @@ class TextStyle {
         this.encodedAttributes.paragraphStyle.minimumLineHeight = args.lineHeight;
         this.encodedAttributes.paragraphStyle.maximumLineHeight = args.lineHeight;
       }
+      if (args.kerning) {
+        this.encodedAttributes.kerning = args.kerning;
+      }
     }
   }
 
@@ -73,6 +76,10 @@ class TextStyle {
 
   getLineHeight() {
     return this.encodedAttributes.paragraphStyle.minimumLineHeight;
+  }
+
+  getKerning() {
+    return this.encodedAttributes.kerning;
   }
 }
 
@@ -98,6 +105,7 @@ TextStyle.Model = {
     },
   },
   verticalAlignment: 0,
+  kerning: 0,
 };
 
 module.exports = TextStyle;

--- a/models/TextStyle/TextStyle.test.js
+++ b/models/TextStyle/TextStyle.test.js
@@ -87,4 +87,16 @@ describe('TextStyle', () => {
     expect(textStyle.encodedAttributes.paragraphStyle.maximumLineHeight).toEqual(10.3);
     expect(textStyle.getLineHeight()).toEqual(10.3);
   });
+
+  it('should not contain kerning if not set', () => {
+    const textStyle = new TextStyle();
+    expect(textStyle.getKerning()).toBeUndefined();
+  });
+
+  it('should contain kerning if set', () => {
+    const textStyle = new TextStyle({
+      kerning: -2.3,
+    });
+    expect(textStyle.getKerning()).toEqual(-2.3);
+  });
 });

--- a/models/TextStyle/TextStyle.test.js
+++ b/models/TextStyle/TextStyle.test.js
@@ -71,4 +71,20 @@ describe('TextStyle', () => {
     });
     expect(textStyle.getFontName()).toEqual('OpenSans');
   });
+
+  it('should not contain line height if not set', () => {
+    const textStyle = new TextStyle();
+    expect(textStyle.encodedAttributes.paragraphStyle.minimumLineHeight).toBeUndefined();
+    expect(textStyle.encodedAttributes.paragraphStyle.maximumLineHeight).toBeUndefined();
+    expect(textStyle.getLineHeight()).toBeUndefined();
+  });
+
+  it('should set both min and max line height for "lineHeight"', () => {
+    const textStyle = new TextStyle({
+      lineHeight: 10.3,
+    });
+    expect(textStyle.encodedAttributes.paragraphStyle.minimumLineHeight).toEqual(10.3);
+    expect(textStyle.encodedAttributes.paragraphStyle.maximumLineHeight).toEqual(10.3);
+    expect(textStyle.getLineHeight()).toEqual(10.3);
+  });
 });

--- a/models/TextStyle/index.d.ts
+++ b/models/TextStyle/index.d.ts
@@ -15,9 +15,12 @@ declare class TextStyle {
     textStyleVerticalAlignmentKey: number;
     underlineStyle: number;
     strikethroughStyle: number;
+    kerning: number;
     paragraphStyle: {
       _class: 'paragraphStyle';
       alignment: number;
+      minimumLineHeight: number;
+      maximumLineHeight: number;
     };
   };
   verticalAlignment: number;
@@ -29,6 +32,10 @@ declare class TextStyle {
   getFontSize(): number;
 
   getFontName(): string;
+
+  getLineHeight(): number;
+
+  getKerning(): number;
 }
 
 export = TextStyle;


### PR DESCRIPTION
*Description of changes:*

Adds support for setting `lineHeight` (Line) and `kerning` (Character) to a TextStyle.

![lineHeight-kerning](https://user-images.githubusercontent.com/15815842/61051999-bf612400-a3ea-11e9-8333-0f036936568b.png)

```
const textStyle = new TextStyle({
  lineHeight: 38,
  kerning: -1.5,
});
```

Only adds the properties to the object if the value is actually passed as an argument. By not setting this we still utilise the built in value in the font file. This is especially important for kerning since a value of `0` is **not** the same as not setting it. Setting kerning to `0` will force kerning pairs to use a fixed spacing of `0` instead of using the built in information in the font kerning pairs.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
