### PR TITLE
feat: add bitmap model

### DIFF
--- a/models/Bitmap/Bitmap.js
+++ b/models/Bitmap/Bitmap.js
@@ -1,0 +1,70 @@
+/*
+ * Copyright 2017 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"). You may not use this file except in compliance with
+ * the License. A copy of the License is located at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+ * CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions
+ * and limitations under the License.
+ */
+
+const uuid = require('uuid-v4');
+const Layer = require('../Layer');
+const Rect = require('../Rect');
+const Style = require('../Style');
+
+/**
+ * A bitmap layer is used for images
+ * @extends Layer
+ *
+ */
+class Bitmap extends Layer {
+  /**
+   *
+   * @param {Object} args
+   * @param {String} args.image The path of the image
+   * @param {Object} args.frame Sent to {@link Rect}
+   * @param {Object} args.style Sent to {@link Style}
+   * @param {Bitmap.Model} json
+   */
+  constructor(args = {}, json) {
+    super(args, json);
+    if (!json) {
+      const id = args.id || uuid().toUpperCase();
+      Object.assign(this, Bitmap.Model, {
+        do_objectID: id,
+        name: args.name || id,
+        frame: new Rect(args.frame),
+        style: new Style(args.style),
+        layers: args.layers || [],
+      });
+    }
+
+    return this;
+  }
+}
+
+/**
+ * @mixes Layer.Model
+ */
+Bitmap.Model = Object.assign({}, Bitmap.Model, {
+  _class: 'bitmap',
+  fillReplacesImage: false,
+  hasClippingMask: false,
+  intendedDPI: 72,
+  layerListExpandedType: 0,
+  resizingConstraint: 63,
+  resizingType: 0,
+  rotation: 0,
+  shouldBreakMaskChain: false,
+  image: {
+    _class: 'MSJSONFileReference',
+    _ref_class: 'MSImageData',
+    _ref: '',
+  },
+});
+
+module.exports = Bitmap;

--- a/models/Bitmap/Bitmap.js
+++ b/models/Bitmap/Bitmap.js
@@ -50,7 +50,7 @@ class Bitmap extends Layer {
 /**
  * @mixes Layer.Model
  */
-Bitmap.Model = Object.assign({}, Bitmap.Model, {
+Bitmap.Model = Object.assign({}, Layer.Model, {
   _class: 'bitmap',
   fillReplacesImage: false,
   hasClippingMask: false,

--- a/models/Bitmap/Bitmap.test.js
+++ b/models/Bitmap/Bitmap.test.js
@@ -1,0 +1,26 @@
+/*
+ * Copyright 2017 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"). You may not use this file except in compliance with
+ * the License. A copy of the License is located at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+ * CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions
+ * and limitations under the License.
+ */
+
+const Fill = require('./index');
+
+const json = {};
+
+describe('Fill', () => {
+  it('should work from raw JSON', () => {
+    expect(true).toBeTruthy();
+  });
+
+  it('should work from user generated', () => {
+    expect(true).toBeTruthy();
+  });
+});

--- a/models/Bitmap/index.d.ts
+++ b/models/Bitmap/index.d.ts
@@ -1,0 +1,70 @@
+/*
+ * Copyright 2017 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"). You may not use this file except in compliance with
+ * the License. A copy of the License is located at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+ * CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions
+ * and limitations under the License.
+ */
+
+ 
+export interface BitmapLayer {
+  _class?: 'bitmapLayer'
+  booleanOperation?: number
+  clippingMask: {
+    [k: string]: any
+  }
+  clippingMaskMode?: number
+  do_objectID?: string
+  exportOptions?: {
+    [k: string]: any
+  }
+  fillReplacesImage?: boolean
+  flow?: {
+    [k: string]: any
+  }
+  frame?: {
+    [k: string]: any
+  }
+  hasClippingMask?: boolean
+  image?: {
+    [k: string]: any
+  }
+  imageSHA?: {
+    [k: string]: any
+  }
+  /**
+   * The scale the image was imported with into Sketch. This can be derived on import from the DPI of the image or the suffixes (@2x) of the filename. On legacy documents defaults to 0, which is meant to be the default image DPI of 72.
+   */
+  intendedDPI?: number
+  isFixedToViewport?: boolean
+  isFlippedHorizontal?: boolean
+  isFlippedVertical?: boolean
+  isLocked?: boolean
+  isVisible?: boolean
+  layerListExpandedType?: number
+  name?: {
+    [k: string]: any
+  }
+  nameIsFixed?: boolean
+  originalObjectID?: {
+    [k: string]: any
+  }
+  resizingConstraint?: number
+  resizingType?: number
+  rotation?: number
+  sharedStyleID?: {
+    [k: string]: any
+  }
+  shouldBreakMaskChain?: boolean
+  style?: {
+    [k: string]: any
+  }
+  userInfo?: {
+    [k: string]: any
+  }
+}

--- a/models/Bitmap/index.d.ts
+++ b/models/Bitmap/index.d.ts
@@ -15,9 +15,7 @@
 export interface BitmapLayer {
   _class?: 'bitmapLayer'
   booleanOperation?: number
-  clippingMask: {
-    [k: string]: any
-  }
+  clippingMask: Record<string, any>
   clippingMaskMode?: number
   do_objectID?: string
   exportOptions?: {
@@ -34,7 +32,7 @@ export interface BitmapLayer {
   image?: {
     [k: string]: any
   }
-  imageSHA?: {
+  imageHash?: {
     [k: string]: any
   }
   /**

--- a/models/Bitmap/index.js
+++ b/models/Bitmap/index.js
@@ -1,0 +1,14 @@
+/*
+ * Copyright 2017 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"). You may not use this file except in compliance with
+ * the License. A copy of the License is located at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+ * CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions
+ * and limitations under the License.
+ */
+
+module.exports = require('./Bitmap');

--- a/models/Sketch/Sketch.js
+++ b/models/Sketch/Sketch.js
@@ -19,6 +19,7 @@ const Document = require('../Document');
 const Page = require('../Page');
 const Artboard = require('../Artboard');
 const SharedStyle = require('../SharedStyle');
+const { STORAGE_DIR, STORAGE_IMG_DIR } = require('../../utils/paths');
 
 class Sketch {
   static fromFile(path) {
@@ -123,10 +124,14 @@ class Sketch {
       .file('meta.json', JSON.stringify(this.meta))
       .file('user.json', JSON.stringify(this.user))
       .file('document.json', JSON.stringify(this.document));
-
     this.zip.folder('pages');
     this.zip.folder('previews');
-
+    if (fs.existsSync(STORAGE_IMG_DIR)) {
+      fs.readdirSync(STORAGE_IMG_DIR).forEach(file => {
+        this.zip.folder('images').file(file, fs.readFile(`${STORAGE_IMG_DIR}/${file}`));
+      });
+    }
+    fs.removeSync(STORAGE_DIR);
     this.pages.forEach(page => {
       this.zip.file(`pages/${page.do_objectID}.json`, JSON.stringify(page));
     });

--- a/models/index.d.ts
+++ b/models/index.d.ts
@@ -1,5 +1,6 @@
 import Artboard from './Artboard';
 import Group from './Group';
+import Bitmap from './Bitmap';
 import Border from './Border';
 import BorderOptions from './BorderOptions';
 import Color from './Color';
@@ -29,6 +30,7 @@ import User from './User';
 export {
   Artboard,
   Group,
+  Bitmap,
   Border,
   BorderOptions,
   Color,

--- a/models/index.js
+++ b/models/index.js
@@ -16,6 +16,7 @@ module.exports = {
   Artboard: require('./Artboard'),
   AttributedString: require('./AttributedString'),
   Group: require('./Group'),
+  Bitmap: require('./Bitmap'),
   Border: require('./Border'),
   BorderOptions: require('./BorderOptions'),
   Color: require('./Color'),

--- a/package-lock.json
+++ b/package-lock.json
@@ -8733,6 +8733,11 @@
       "integrity": "sha1-izqsWIuKZuSXXjzepn97sylgH6w=",
       "dev": true
     },
+    "md5-file": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/md5-file/-/md5-file-4.0.0.tgz",
+      "integrity": "sha512-UC0qFwyAjn4YdPpKaDNw6gNxRf7Mcx7jC1UGCY4boCzgvU2Aoc1mOGzTtrjjLKhM5ivsnhoKpQVxKPp+1j1qwg=="
+    },
     "medium-zoom": {
       "version": "0.4.0",
       "resolved": "https://registry.npmjs.org/medium-zoom/-/medium-zoom-0.4.0.tgz",

--- a/package.json
+++ b/package.json
@@ -68,6 +68,7 @@
     "@types/tinycolor2": "^1.4.2",
     "fs-extra": "^7.0.1",
     "jszip": "^3.1.5",
+    "md5-file": "^4.0.0",
     "tinycolor2": "^1.4.1",
     "uuid-v4": "^0.1.0"
   },

--- a/utils/paths.js
+++ b/utils/paths.js
@@ -11,9 +11,17 @@
  * and limitations under the License.
  */
 
+/**
+ * Path to the temporary local image folder
+ */
+const STORAGE_IMG_DIR = '.sketch-constructor/images';
+
+/**
+ * Path to the temporary sketch constructor folder
+ */
+const STORAGE_DIR = '.sketch-constructor';
+
 module.exports = {
-  layerToClass: require('./layerToClass'),
-  stackLayers: require('./stackLayers'),
-  maps: require('./maps'),
-  paths: require('./paths'),
+  STORAGE_DIR,
+  STORAGE_IMG_DIR,
 };


### PR DESCRIPTION
*Description of changes:* First draft of the image feature implementation.

@dbanksdesign you were right, the ID isn't actually an ID, its an MD5 hash of the file ;-) good catch!

Additionally I thought it would be a good idea to copy the images over to a temporary directory (`.sketch-constructor/images`) so no file changes can occur during the build process. The image files are being copied to the directory when a new bitmap object is created. The nice thing about it is, that we can then in the `build()` function also just read all files out of the directory and add them to the Sketch zip file (no need to traverse through all nodes in the JSON *wohooo* 🚀). After the build is done, I simply delete the directory to not leave behind any unused files.

Let me know what you think about the current implementation. Also if you have any suggestions on how to re-structure the code, lmk.

Cheers


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
