### PR TITLE
fix: export AttributedString and StringAttribute typings

### DIFF
--- a/models/index.d.ts
+++ b/models/index.d.ts
@@ -1,4 +1,5 @@
 import Artboard from './Artboard';
+import AttributedString from './AttributedString';
 import Group from './Group';
 import Border from './Border';
 import BorderOptions from './BorderOptions';
@@ -21,6 +22,7 @@ import ShapeGroup from './ShapeGroup';
 import ShapePath from './ShapePath';
 import SharedStyle from './SharedStyle';
 import Sketch from './Sketch';
+import StringAttribute from './StringAttribute';
 import Style from './Style';
 import SymbolInstance from './SymbolInstance';
 import SymbolMaster from './SymbolMaster';
@@ -30,6 +32,7 @@ import User from './User';
 
 export {
   Artboard,
+  AttributedString,
   Group,
   Border,
   BorderOptions,
@@ -52,6 +55,7 @@ export {
   ShapePath,
   SharedStyle,
   Sketch,
+  StringAttribute,
   Style,
   SymbolInstance,
   SymbolMaster,


### PR DESCRIPTION
*Description of changes:*
AttributedString and StringAttribute are exported by js file but missed in typescript definitions

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
