### PR TITLE
feat: added support for different Bitmap file extensions

### DIFF
--- a/models/Bitmap/Bitmap.js
+++ b/models/Bitmap/Bitmap.js
@@ -60,7 +60,8 @@ class Bitmap extends Layer {
   /**
    *
    * @param {Object} args
-   * @param {String} args.filePath Local path of the image in PNG format
+   * @param {String} args.filePath Local path of the image
+   * @param {String} args.fileExt Extension of the image
    * @param {Object} args.frame Sent to {@link Rect}
    * @param {Object} args.style Sent to {@link Style}
    * @param {Bitmap.Model} json
@@ -77,7 +78,8 @@ class Bitmap extends Layer {
         layers: args.layers || [],
       });
       const fileHash = md5File.sync(args.filePath);
-      this.image._ref = `images/${fileHash}.png`;
+      const fileExt = args.fileExt || 'png';
+      this.image._ref = `images/${fileHash}.${fileExt}`;
       fs.ensureDirSync(STORAGE_IMG_DIR);
       fs.copyFileSync(args.filePath, `${STORAGE_DIR}/${this.image._ref}`);
     }

--- a/models/Bitmap/index.d.ts
+++ b/models/Bitmap/index.d.ts
@@ -11,58 +11,24 @@
  * and limitations under the License.
  */
 
- 
-export interface BitmapLayer {
-  _class?: 'bitmapLayer'
-  booleanOperation?: number
-  clippingMask: Record<string, any>
-  clippingMaskMode?: number
-  do_objectID?: string
-  exportOptions?: {
-    [k: string]: any
-  }
-  fillReplacesImage?: boolean
-  flow?: {
-    [k: string]: any
-  }
-  frame?: {
-    [k: string]: any
-  }
-  hasClippingMask?: boolean
-  image?: {
-    [k: string]: any
-  }
-  imageHash?: {
-    [k: string]: any
-  }
+import Layer = require('../Layer');
+
+declare class Bitmap extends Layer {
+  _class: 'bitmapLayer';
+  clippingMask: Record<string, any>;
+  clippingMaskMode?: number;
+  fillReplacesImage?: boolean;
+  flow?: Record<string, any>;
+  hasClippingMask?: boolean;
+  image?: Record<string, any>;
+  imageHash?: Record<string, any>;
   /**
    * The scale the image was imported with into Sketch. This can be derived on import from the DPI of the image or the suffixes (@2x) of the filename. On legacy documents defaults to 0, which is meant to be the default image DPI of 72.
    */
-  intendedDPI?: number
-  isFixedToViewport?: boolean
-  isFlippedHorizontal?: boolean
-  isFlippedVertical?: boolean
-  isLocked?: boolean
-  isVisible?: boolean
-  layerListExpandedType?: number
-  name?: {
-    [k: string]: any
-  }
-  nameIsFixed?: boolean
-  originalObjectID?: {
-    [k: string]: any
-  }
-  resizingConstraint?: number
-  resizingType?: number
-  rotation?: number
-  sharedStyleID?: {
-    [k: string]: any
-  }
-  shouldBreakMaskChain?: boolean
-  style?: {
-    [k: string]: any
-  }
-  userInfo?: {
-    [k: string]: any
-  }
+  intendedDPI?: number;
+  originalObjectID?: Record<string, any>;
+  sharedStyleID?: Record<string, any>;
+  userInfo?: Record<string, any>;
 }
+
+export = Bitmap


### PR DESCRIPTION
*Description of changes:*
Now you can pass file extension in Bitmap constructor, fallback to 'png' to backward compatibility

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
