### PR TITLE
fix: remove storage dir after Sketch was built

### DIFF
--- a/models/Sketch/Sketch.js
+++ b/models/Sketch/Sketch.js
@@ -170,13 +170,13 @@ class Sketch {
         this.zip.folder('images').file(file, fs.readFile(`${STORAGE_IMG_DIR}/${file}`));
       });
     }
-    fs.removeSync(STORAGE_DIR);
     this.pages.forEach(page => {
       this.zip.file(`pages/${page.do_objectID}.json`, JSON.stringify(page));
     });
 
     return this.zip.generateAsync({ type: 'nodebuffer', streamFiles: true }).then(buffer => {
       fs.writeFileSync(output, buffer);
+      fs.removeSync(STORAGE_DIR);
       return output;
     });
   }


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Time to time we faced with issue when directory was removed before images were read. So I moved storage dir removing after sketch file build.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
