### PR TITLE
chore: specify module type

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
   "version": "0.0.0-development",
   "description": "Read/write/manipulate Sketch files in Node without Sketch plugins!",
   "main": "index.js",
+  "type": "commonjs",
   "types": "index.d.ts",
   "files": [
     "models",


### PR DESCRIPTION
*Description of changes:*
Since nodejs 13.2.0 ES modules enabled by default and it would be better to exactly specify that package is written with CommonJS modules
ref: https://medium.com/@nodejs/announcing-core-node-js-support-for-ecmascript-modules-c5d6dc29b663

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
