### PR TITLE
Allow to set background color

### DIFF
--- a/models/Artboard/Artboard.js
+++ b/models/Artboard/Artboard.js
@@ -77,7 +77,7 @@ class Artboard extends Group {
         style: new Style(args.style),
         layers: args.layers || [],
         backgroundColor: new Color(args.backgroundColor || '#fff'),
-        hasBackgroundColor: args.backgroundColor ? true : false,
+        hasBackgroundColor: args.backgroundColor != null,
         horizontalRulerData: new RulerData(args.horizontalRulerData),
         verticalRulerData: new RulerData(args.verticalRulerData),
       });

--- a/models/Artboard/Artboard.js
+++ b/models/Artboard/Artboard.js
@@ -77,6 +77,7 @@ class Artboard extends Group {
         style: new Style(args.style),
         layers: args.layers || [],
         backgroundColor: new Color(args.backgroundColor || '#fff'),
+        hasBackgroundColor: args.backgroundColor ? true : false,
         horizontalRulerData: new RulerData(args.horizontalRulerData),
         verticalRulerData: new RulerData(args.verticalRulerData),
       });


### PR DESCRIPTION
Artboard object needs to have `hasBackgroundColor` set to true in order to allow a background color.

