### PR TITLE
fix(SharedStyle): delegate args to Shared.TextStyle properly

### DIFF
--- a/__examples__/generating-sketch-from-style-dictionary/sketch/index.js
+++ b/__examples__/generating-sketch-from-style-dictionary/sketch/index.js
@@ -26,8 +26,10 @@ module.exports = function BuildSketchWithStyles(dictionary) {
     const font = dictionary.properties.component.typography[key];
     sketch.addTextStyle({
       name: key,
-      fontSize: font['font-size'].value,
-      color: font.color.value,
+      textStyle: {
+        fontSize: font['font-size'].value,
+        color: font.color.value,
+      },
     });
   });
 

--- a/models/SharedStyle/SharedStyle.js
+++ b/models/SharedStyle/SharedStyle.js
@@ -12,7 +12,6 @@
  */
 
 const uuid = require('uuid-v4');
-const TextStyle = require('../TextStyle');
 const Style = require('../Style');
 
 class SharedStyle {
@@ -32,7 +31,7 @@ class SharedStyle {
     return new SharedStyle({
       name: args.name,
       id,
-      textStyle: new TextStyle(Object.assign(args, { id })),
+      textStyle: args.textStyle,
     });
   }
 

--- a/models/SharedStyle/SharedStyle.test.js
+++ b/models/SharedStyle/SharedStyle.test.js
@@ -40,4 +40,20 @@ describe('SharedStyle', () => {
       expect(layerStyle.value.fills[0].color.red).toEqual(1);
     });
   });
+
+  describe('TextStyle', () => {
+    it('should work', () => {
+      const textStyle = SharedStyle.TextStyle({
+        name: 'test',
+        textStyle: {
+          fontName: 'Arial',
+          fontSize: 10,
+        },
+      });
+      expect(textStyle.value.textStyle.encodedAttributes.MSAttributedStringFontAttribute.attributes).toEqual({
+        name: 'Arial',
+        size: 10,
+      });
+    });
+  });
 });


### PR DESCRIPTION
*Issue #84*

*Description of changes:*

- Apply the same logic for `SharedStyle.TextStyle` than `SharedStyle.LayerStyle` to ensure the args delegation throw constructors.

- Added test

- Update example


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
