### PR TITLE
feat(Sketch): add compression level option to build

### DIFF
--- a/models/Sketch/Sketch.js
+++ b/models/Sketch/Sketch.js
@@ -154,7 +154,7 @@ class Sketch {
     this.meta.addArtboard(pageID, artboard);
   }
 
-  build(output) {
+  build(output, compressionLevel = 0) {
     this.zip
       .file('meta.json', JSON.stringify(this.meta))
       .file('user.json', JSON.stringify(this.user))
@@ -174,11 +174,18 @@ class Sketch {
       this.zip.file(`pages/${page.do_objectID}.json`, JSON.stringify(page));
     });
 
-    return this.zip.generateAsync({ type: 'nodebuffer', streamFiles: true }).then(buffer => {
-      fs.writeFileSync(output, buffer);
-      fs.removeSync(STORAGE_DIR);
-      return output;
-    });
+    return this.zip
+      .generateAsync({
+        type: 'nodebuffer',
+        streamFiles: true,
+        compression: compressionLevel === 0 ? 'STORE' : 'DEFLATE',
+        compressionOptions: { level: compressionLevel },
+      })
+      .then(buffer => {
+        fs.writeFileSync(output, buffer);
+        fs.removeSync(STORAGE_DIR);
+        return output;
+      });
   }
 }
 

--- a/models/Sketch/index.d.ts
+++ b/models/Sketch/index.d.ts
@@ -39,7 +39,7 @@ declare class Sketch {
 
   addArtboard(pageID: string, artboard: any): void;
 
-  build(output: fs.PathLike | number): Promise<fs.PathLike | number>;
+  build(output: fs.PathLike | number, compressLevel: number): Promise<fs.PathLike | number>;
 }
 
 export = Sketch;


### PR DESCRIPTION
*Issue #91*

*Description of changes:*
Enable compressLevel option in the Sketch.build function to be able to compress the output file. The value is 0 by default (no compression) and it raise to 9 to highest compression (less speed).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
