### PR TITLE
fix(Sketch): set correct arg name in build method

### DIFF
--- a/models/Sketch/index.d.ts
+++ b/models/Sketch/index.d.ts
@@ -39,7 +39,7 @@ declare class Sketch {
 
   addArtboard(pageID: string, artboard: any): void;
 
-  build(output: fs.PathLike | number, compressLevel: number): Promise<fs.PathLike | number>;
+  build(output: fs.PathLike | number, compressionLevel: number): Promise<fs.PathLike | number>;
 }
 
 export = Sketch;


### PR DESCRIPTION
*Description of changes:*
Fix typo in the argument name for build method in the typescript definition file.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
