### PR TITLE
fix(Page): enable to set id from arguments

### DIFF
--- a/models/Page/Page.js
+++ b/models/Page/Page.js
@@ -36,7 +36,7 @@ class Page extends Group {
   constructor(args = {}, json) {
     super(args, json);
     if (!json) {
-      const id = uuid().toUpperCase();
+      const id = args.id || uuid().toUpperCase();
       Object.assign(this, Page.Model, {
         do_objectID: id,
         name: args.name || id,


### PR DESCRIPTION
*Description of changes:*
Page was the only class that it wasn't enable to define the object id. This PR solve this and unify the id logic in all classes

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
