### PR TITLE
fix(Page): enable to set id from arguments

### DIFF
--- a/models/Page/Page.js
+++ b/models/Page/Page.js
@@ -36,7 +36,7 @@ class Page extends Group {
   constructor(args = {}, json) {
     super(args, json);
     if (!json) {
-      const id = uuid().toUpperCase();
+      const id = args.id || uuid().toUpperCase();
       Object.assign(this, Page.Model, {
         do_objectID: id,
         name: args.name || id,


### PR DESCRIPTION
*Issue #97*

*Description of changes:*
- Add a helper for resizingConstraint (`resizingConstraintValues` and `calculateResizingConstraintValues()`)
- Change all hard coded values to constraints
- Set `resizingConstraintValues.none` by default to all layers except text, that has `resizingConstraintValues.height`.
- Remove Bitmap model property `resizingConstraint` because extends Layers with the same value.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
