### PR TITLE
feat: add resizingConstraint API

### DIFF
--- a/__tests__/utils/resizingConstraints.test.js
+++ b/__tests__/utils/resizingConstraints.test.js
@@ -1,0 +1,36 @@
+const { calculateResizingConstraint } = require('../../utils/resizingConstraints.js');
+const { resizingConstraintsMap } = require('../../utils/maps.js');
+
+describe('Test sizing constraints', () => {
+  test('reduce series of numbers to their bitwise AND value', () => {
+    const { top, left, height } = resizingConstraintsMap;
+    const input = [left, height];
+    // eslint-disable-next-line no-bitwise
+    const output = top & left & height;
+
+    expect(calculateResizingConstraint(top, ...input)).toEqual(output);
+  });
+
+  test('given undefined values will return `none` (63)', () => {
+    const { top, wat, none } = resizingConstraintsMap;
+    const output = none;
+
+    expect(calculateResizingConstraint(top, wat)).toEqual(output);
+  });
+
+  describe('when given invalid combinations', () => {
+    test('will throw when top, bottom & height are specified', () => {
+      const { top, bottom, height } = resizingConstraintsMap;
+      const input = [bottom, height];
+
+      expect(() => calculateResizingConstraint(top, ...input)).toThrow();
+    });
+
+    test('will throw when left, right & width are specified', () => {
+      const { left, right, width } = resizingConstraintsMap;
+      const input = [right, width];
+
+      expect(() => calculateResizingConstraint(left, ...input)).toThrow();
+    });
+  });
+});

--- a/models/Bitmap/Bitmap.js
+++ b/models/Bitmap/Bitmap.js
@@ -32,7 +32,6 @@ class Bitmap extends Layer {
    * @property {boolean} hasClippingMask
    * @property {integer} intendedDPI
    * @property {integer} layerListExpandedType
-   * @property {integer} resizingConstraint
    * @property {integer} resizingType
    * @property {float} rotation
    * @property {boolean} shouldBreakMaskChain
@@ -46,7 +45,6 @@ class Bitmap extends Layer {
       hasClippingMask: false,
       intendedDPI: 72,
       layerListExpandedType: 0,
-      resizingConstraint: 63,
       resizingType: 0,
       rotation: 0,
       shouldBreakMaskChain: false,

--- a/models/Layer/Layer.js
+++ b/models/Layer/Layer.js
@@ -14,6 +14,7 @@
 const ExportOptions = require('../ExportOptions');
 const Rect = require('../Rect');
 const Style = require('../Style');
+const { resizingConstraintsMap } = require('../../utils/maps.js');
 
 /**
  * Base layer class
@@ -49,7 +50,7 @@ class Layer {
       layerListExpandedType: 0,
       name: '',
       nameIsFixed: false,
-      resizingConstraint: 47,
+      resizingConstraint: resizingConstraintsMap.none,
       resizingType: 0,
       rotation: 0,
       shouldBreakMaskChain: false,

--- a/models/Text/Text.js
+++ b/models/Text/Text.js
@@ -17,6 +17,7 @@ const Layer = require('../Layer');
 const Style = require('../Style');
 const AttributedString = require('../AttributedString');
 const { textBehaviourMap } = require('../../utils/maps');
+const { resizingConstraintsMap } = require('../../utils/maps.js');
 
 /**
  * Text Layer Class
@@ -81,7 +82,7 @@ class Text extends Layer {
         layers: [],
         name: args.name || id,
         nameIsFixed: false,
-        resizingConstraint: 47,
+        resizingConstraint: resizingConstraintsMap.height,
         resizingType: 0,
         rotation: 0,
         shouldBreakMaskChain: false,

--- a/utils/maps.js
+++ b/utils/maps.js
@@ -93,10 +93,29 @@ Object.keys(blendModeMap).forEach(key => {
   blendModeMap[blendModeMap[key]] = key;
 });
 
+/**
+ * Maps resizing contrains int enums to human-readable strings
+ * @example
+ * resizingConstraintsMap.top // => 31
+ */
+const resizingConstraintsMap = {
+  top: 31,
+  right: 62,
+  bottom: 55,
+  left: 59,
+  width: 61,
+  height: 47,
+  none: 63,
+};
+
+const containsAllItems = (needles, haystack) => needles.every(needle => haystack.includes(needle));
+
 module.exports = {
   textAlignmentMap,
   verticalAlignmentMap,
   textTransformMap,
   textBehaviourMap,
   blendModeMap,
+  resizingConstraintsMap,
+  containsAllItems,
 };

--- a/utils/resizingConstraints.js
+++ b/utils/resizingConstraints.js
@@ -1,0 +1,23 @@
+const { containsAllItems, resizingConstraintsMap } = require('./maps.js');
+
+const noHeight = [resizingConstraintsMap.top, resizingConstraintsMap.bottom, resizingConstraintsMap.height];
+const noWidth = [resizingConstraintsMap.left, resizingConstraintsMap.right, resizingConstraintsMap.width];
+
+/*
+ * Sketch use Bit Masks to store the resizing settings.
+ * To calculate the compound settings use the AND (&) bitwise operator.
+ */
+const calculateResizingConstraint = (...args) => {
+  if (containsAllItems(noHeight, args)) {
+    throw new Error("Can't fix height when top & bottom are fixed");
+  }
+  if (containsAllItems(noWidth, args)) {
+    throw new Error("Can't fix width when left & right are fixed");
+  }
+
+  const [first, ...rest] = args;
+  // eslint-disable-next-line no-bitwise
+  return rest.reduce((acc, item) => acc & item, first) || resizingConstraintsMap.none;
+};
+
+module.exports = { calculateResizingConstraint };


### PR DESCRIPTION
*Issue #97*

*Description of changes:*
- Add a helper for resizingConstraint (`resizingConstraintValues` and `calculateResizingConstraintValues()`)
- Change all hard coded values to constraints
- Set `resizingConstraintValues.none` by default to all layers except text, that has `resizingConstraintValues.height`.
- Remove Bitmap model property `resizingConstraint` because extends Layers with the same value.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
