### PR TITLE
fix: Use SHA1 instead of MD5 to hash image file names

### DIFF
--- a/models/Bitmap/Bitmap.js
+++ b/models/Bitmap/Bitmap.js
@@ -13,7 +13,7 @@
 
 const uuid = require('uuid-v4');
 const fs = require('fs-extra');
-const md5File = require('md5-file');
+const crypto = require('crypto');
 const Layer = require('../Layer');
 const Rect = require('../Rect');
 const Style = require('../Style');
@@ -75,7 +75,10 @@ class Bitmap extends Layer {
         style: new Style(args.style),
         layers: args.layers || [],
       });
-      const fileHash = md5File.sync(args.filePath);
+      const fileHash = crypto
+        .createHash('sha1')
+        .update(args.filePath)
+        .digest('hex');
       this.image._ref = `images/${fileHash}.png`;
       fs.ensureDirSync(STORAGE_IMG_DIR);
       fs.copyFileSync(args.filePath, `${STORAGE_DIR}/${this.image._ref}`);

--- a/package-lock.json
+++ b/package-lock.json
@@ -8896,11 +8896,6 @@
         "supports-hyperlinks": "^1.0.1"
       }
     },
-    "md5-file": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/md5-file/-/md5-file-4.0.0.tgz",
-      "integrity": "sha512-UC0qFwyAjn4YdPpKaDNw6gNxRf7Mcx7jC1UGCY4boCzgvU2Aoc1mOGzTtrjjLKhM5ivsnhoKpQVxKPp+1j1qwg=="
-    },
     "mdurl": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/mdurl/-/mdurl-1.0.1.tgz",

--- a/package.json
+++ b/package.json
@@ -69,7 +69,6 @@
     "@types/tinycolor2": "^1.4.2",
     "fs-extra": "^8.1.0",
     "jszip": "^3.1.5",
-    "md5-file": "^4.0.0",
     "tinycolor2": "^1.4.1",
     "uuid-v4": "^0.1.0"
   },


### PR DESCRIPTION
*Description of changes:*
I found out that Sketch uses SHA1 instead of MD5 to hash filenames for images. This PR fixes that.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
