### PR TITLE
fix(map): fix vertical alignment map

### DIFF
--- a/__examples__/generating-sketch-from-style-dictionary/package-lock.json
+++ b/__examples__/generating-sketch-from-style-dictionary/package-lock.json
@@ -222,7 +222,7 @@
     },
     "path-is-absolute": {
       "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
+      "resolved": "http://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
       "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18="
     },
     "process-nextick-args": {

--- a/utils/maps.js
+++ b/utils/maps.js
@@ -45,7 +45,7 @@ const textTransformMap = {
   lowercase: 2,
 };
 
-Object.keys(textAlignmentMap).forEach(key => {
+Object.keys(textAlignmentMap).forEach((key) => {
   textAlignmentMap[textAlignmentMap[key]] = key;
 });
 
@@ -56,11 +56,11 @@ Object.keys(textAlignmentMap).forEach(key => {
  */
 const verticalAlignmentMap = {
   top: 0,
-  bottom: 1,
-  center: 2,
+  middle: 1,
+  bottom: 2,
 };
 
-Object.keys(verticalAlignmentMap).forEach(key => {
+Object.keys(verticalAlignmentMap).forEach((key) => {
   verticalAlignmentMap[verticalAlignmentMap[key]] = key;
 });
 
@@ -90,7 +90,7 @@ const blendModeMap = {
   plusLighter: 17,
 };
 
-Object.keys(blendModeMap).forEach(key => {
+Object.keys(blendModeMap).forEach((key) => {
   blendModeMap[blendModeMap[key]] = key;
 });
 
@@ -109,7 +109,7 @@ const resizingConstraintsMap = {
   none: 63,
 };
 
-const containsAllItems = (needles, haystack) => needles.every(needle => haystack.includes(needle));
+const containsAllItems = (needles, haystack) => needles.every((needle) => haystack.includes(needle));
 
 module.exports = {
   textAlignmentMap,


### PR DESCRIPTION
*Issue #, if available:* #112

*Description of changes:* Bottom and middle were flipped. Updated the map based on the sketch file schema: https://github.com/sketch-hq/sketch-file-format/blob/master/schema/enums/text-vertical-alignment.schema.yaml


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
