### PR TITLE
fix: add Blur module loading index, basic test

### DIFF
--- a/models/Blur/Blur.test.js
+++ b/models/Blur/Blur.test.js
@@ -11,4 +11,17 @@
  * and limitations under the License.
  */
 
-module.exports = require('./Blur');
+const Blur = require('./index');
+
+const json = {};
+
+describe('Blur', () => {
+  it('should work from raw JSON', () => {
+    expect(true).toBeTruthy();
+  });
+
+  it('should work from user generated', () => {
+    const blur = new Blur({});
+    expect(true).toBeTruthy();
+  });
+});


### PR DESCRIPTION
*Description of changes:*
`Blur` didn't have the module loading line in its `index.js` so was throwing `TypeError: Blur is not a constructor` when you try to instantiate it.
e.g.:
```
const Blur = require('./models/Blur');
new Blur({});
```
would result in
```
Thrown:
TypeError: Blur is not a constructor
```

Doing similar with, for example, the `Fill` class/module would work fine though.

So this change just adds the module export to `index.js` for `Blur` and also adds a basic test to `Blur`.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
