### PR TITLE
fix(meta): Change save history to match build number

### DIFF
--- a/models/Meta/Meta.js
+++ b/models/Meta/Meta.js
@@ -42,7 +42,7 @@ class Meta {
         version: 134,
         variant: 'NONAPPSTORE',
       },
-      saveHistory: ['NONAPPSTORE.67469'],
+      saveHistory: ['NONAPPSTORE.107357'],
       appVersion: '69',
       build: 107357,
     };


### PR DESCRIPTION
*Description of changes:*
Changes the last saved data to match the current build number.

Not doing this was an oversight in #164.

I’m not aware of it causing any problems but it seems prudent to fix it anyway.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
